### PR TITLE
Initial implementation for BIDS reading task

### DIFF
--- a/pydra/tasks/bids/utils/read_bids.py
+++ b/pydra/tasks/bids/utils/read_bids.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+from pydra.engine.task import FunctionTask
+
+DEFAULT_QUERY = {
+    "bold": {
+        "suffix": "bold",
+        "extension": [".nii", ".nii.gz"],
+    },
+    "T1w": {
+        "suffix": "T1w",
+        "extension": [".nii", ".nii.gz"],
+    },
+}
+
+
+def read_bids(output_query: Optional[dict] = None) -> FunctionTask:
+    """Generate a BIDS reading task.
+
+    :param output_query: Mapping between output and BIDS query
+    :type: dict
+    :return: BIDS reading task
+    :rtype: pydra.engine.task.FunctionTask
+
+    Examples
+    --------
+
+    >>> task = read_bids()
+    >>> task.output_names
+    ['bold', 'T1w']
+    """
+    from os import PathLike
+
+    from pydra.engine.specs import BaseSpec, SpecInfo
+
+    output_query = output_query or DEFAULT_QUERY
+
+    def inner(base_dir):
+        from ancpbids import BIDSLayout
+
+        layout = BIDSLayout(ds_dir=base_dir)
+
+        results = {
+            key: layout.get(return_type="files", **query)
+            for key, query in list(output_query.items())
+        }
+
+        return tuple(results.values())
+
+    input_spec = SpecInfo(
+        name="Input",
+        fields=[
+            (
+                "base_dir",
+                PathLike,
+                {"help_string": "Root directory of the BIDS dataset"},
+            ),
+        ],
+        bases=(BaseSpec,),
+    )
+
+    output_spec = SpecInfo(
+        name="Output",
+        fields=[(key, str) for key in list(output_query.keys())],
+        bases=(BaseSpec,),
+    )
+
+    return FunctionTask(func=inner, input_spec=input_spec, output_spec=output_spec)


### PR DESCRIPTION
First attempt at providing a BIDS reading task with a similar interface as nipype's BIDSDataGrabber.

```python
from pydra.tasks.bids import read_bids

task = read_bids()  # Defaults to T1w and bold query
result = task(base_dir)
```