### PR TITLE
Add targets for managing locked dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -575,7 +575,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8ab10c774faf3497c4a87446a969b6dae6d14ef9e4d3e9ae3a6f34f32a580b06"
+content-hash = "66d67f56aa78057baa8da35fd20de0215c2700581870d78a77cca6a8ac91944f"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,11 @@ black = "^22.8.0"
 isort = "^5.10.1"
 
 [tool.poetry.group.docs.dependencies]
-Sphinx = "^5"
-numpydoc = "^1.4"
+Sphinx = "^5.2.3"
+numpydoc = "^1.4.0"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7"
+pytest = "^7.1.3"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- lock: regenerate the lock file without updating
- check-lock: check lock file in consistent with project file
- install: cannot be run if lock file is inconsistent