### PR TITLE
Rename BIDSDataReader to BIDSDatasetReader

### DIFF
--- a/pydra/tasks/bids/__init__.py
+++ b/pydra/tasks/bids/__init__.py
@@ -5,6 +5,6 @@ Import Pydra's engine and BIDS tasks.
 >>> import pydra.engine
 >>> import pydra.tasks.bids
 """
-from .utils import BIDSDataReader, BIDSFileInfo
+from .utils import BIDSDatasetReader, BIDSFileInfo
 
-__all__ = ["BIDSDataReader", "BIDSFileInfo"]
+__all__ = ["BIDSDatasetReader", "BIDSFileInfo"]

--- a/pydra/tasks/bids/tests/test_utils.py
+++ b/pydra/tasks/bids/tests/test_utils.py
@@ -9,7 +9,7 @@ def test_bfi_defaults():
 
 
 def test_bdr_defaults():
-    task = utils.BIDSDataReader().to_task()
+    task = utils.BIDSDatasetReader().to_task()
 
     assert "dataset_path" in task.input_names
     assert {"T1w", "bold"} == set(task.output_names)

--- a/pydra/tasks/bids/utils.py
+++ b/pydra/tasks/bids/utils.py
@@ -3,7 +3,7 @@ from typing import Iterable, Union
 
 import pydra
 
-__all__ = ["BIDSFileInfo", "BIDSDataReader"]
+__all__ = ["BIDSFileInfo", "BIDSDatasetReader"]
 
 
 class BIDSFileInfo:
@@ -98,7 +98,7 @@ class BIDSFileInfo:
         )
 
 
-class BIDSDataReader:
+class BIDSDatasetReader:
     """Read files from a BIDS dataset.
 
     Attributes
@@ -111,7 +111,7 @@ class BIDSDataReader:
 
     Fetch all T1w scans and make them available under the "out" named output:
 
-    >>> task = BIDSDataReader(
+    >>> task = BIDSDatasetReader(
     ...     output_query={
     ...         "out": {
     ...             "suffix": "T1w",


### PR DESCRIPTION
Makes naming more explicit that the task operates at the dataset level.