### PR TITLE
FIX: Return prefix in output entities parsed by BIDSFileInfo

### DIFF
--- a/pydra/tasks/bids/tests/test_utils.py
+++ b/pydra/tasks/bids/tests/test_utils.py
@@ -8,6 +8,13 @@ def test_bfi_defaults():
     assert {"entities", "suffix", "extension"} == set(task.output_names)
 
 
+def test_bfi_with_output_entities():
+    output_entities = {"participant_id": "sub", "run_id": "run"}
+    task = utils.BIDSFileInfo(output_entities=output_entities).to_task()
+
+    assert set(output_entities.keys()).issubset(task.output_names)
+
+
 def test_bdr_defaults():
     task = utils.BIDSDatasetReader().to_task()
 

--- a/pydra/tasks/bids/tests/test_utils.py
+++ b/pydra/tasks/bids/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_bdr_defaults():
 
 
 def test_bdr_with_output_query():
-    task = utils.BIDSDatasetReader(
-        output_query={"T1w": {"suffix": "T1w"}, "bold": {"suffix": "bold"}}
-    ).to_task()
-    assert {"T1w", "bold"}.issubset(task.output_names)
+    output_query = {"T1w": {"suffix": "T1w"}, "bold": {"suffix": "bold"}}
+    task = utils.BIDSDatasetReader(output_query=output_query).to_task()
+
+    assert set(output_query.keys()).issubset(task.output_names)

--- a/pydra/tasks/bids/utils.py
+++ b/pydra/tasks/bids/utils.py
@@ -30,18 +30,18 @@ class BIDSFileInfo:
 
     >>> task = BIDSFileInfo(
     ...     output_entities={
-    ...         "subject": "sub",
-    ...         "session": "ses",
-    ...         "tracer": "trc",
+    ...         "participant_id": "sub",
+    ...         "session_id": "ses",
+    ...         "tracer_id": "trc",
     ...     },
     ... ).to_task()
     >>> result = task(file_path="sub-P01_ses-M00_trc-18FFDG_pet.nii.gz")
-    >>> result.output.subject
-    'P01'
-    >>> result.output.session
-    'M00'
-    >>> result.output.tracer
-    '18FFDG'
+    >>> result.output.participant_id
+    'sub-P01'
+    >>> result.output.session_id
+    'ses-M00'
+    >>> result.output.tracer_id
+    'trc-18FFDG'
     """
 
     def __init__(self, output_entities: dict = None):
@@ -58,7 +58,8 @@ class BIDSFileInfo:
 
         # Extract extra entities to provide as output.
         extra_entities = [
-            entities.get(entity) for entity in self.output_entities.values()
+            f"{entity}-{entities.get(entity)}"
+            for entity in self.output_entities.values()
         ]
 
         return tuple([entities, suffix, extension] + extra_entities)


### PR DESCRIPTION
Custom names in `output_entities` mapping can lie, entity prefix don't. Better keep them than sorry.